### PR TITLE
Handle case of hudson.Extension doesn't already exist for Eclipse.

### DIFF
--- a/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer6.java
+++ b/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer6.java
@@ -190,7 +190,13 @@ public class Indexer6 extends AbstractProcessor {
                 } catch (FileNotFoundException x) {
                     // OK, created for the first time
                 } catch (IOException x) {
-                    // OK, created for the first time
+                    String filerClassname = processingEnv.getFiler().getClass().getCanonicalName();
+                    if( filerClassname.startsWith("org.eclipse.")) { // if eclipse
+                        //    OK, created for the first time
+                    } else {
+                        // rethrow
+                        throw x;
+                    }
                 }
                 FileObject out = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT,
                         "", "META-INF/annotations/" + annName,
@@ -207,7 +213,9 @@ public class Indexer6 extends AbstractProcessor {
                     os.close();
                 }
             } catch (IOException x) {
-                x.printStackTrace();
+                for( Element element : originatingElementsByAnn.get(annName) ) {
+                    processingEnv.getMessager().printMessage(Kind.ERROR, x.toString(), element );
+                }
                 processingEnv.getMessager().printMessage(Kind.ERROR, x.toString());
             }
         }

--- a/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer6.java
+++ b/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer6.java
@@ -189,6 +189,8 @@ public class Indexer6 extends AbstractProcessor {
                     }
                 } catch (FileNotFoundException x) {
                     // OK, created for the first time
+                } catch (IOException x) {
+                    // OK, created for the first time
                 }
                 FileObject out = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT,
                         "", "META-INF/annotations/" + annName,
@@ -205,6 +207,7 @@ public class Indexer6 extends AbstractProcessor {
                     os.close();
                 }
             } catch (IOException x) {
+                x.printStackTrace();
                 processingEnv.getMessager().printMessage(Kind.ERROR, x.toString());
             }
         }

--- a/sezpoz/src/main/resources/META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
+++ b/sezpoz/src/main/resources/META-INF/services/com.sun.mirror.apt.AnnotationProcessorFactory
@@ -1,1 +1,0 @@
-net.java.sezpoz.impl.IndexerFactory


### PR DESCRIPTION
re: only catch IOException when using Eclipse filer:
- good idea. done

re: apply message to each associated item
- good idea. done

re: you didn't file a pull request
- ok. doing that now

Note, I've also purged a META-INF/services file, which I think is now obsolete? and causes a build error on eclipse ("IndexerFactory not found")