### PR TITLE
Serialize indexed annotations as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings/
 target/
+*.swp


### PR DESCRIPTION
To support Java classpath libraries whose `TreeMap` has a serialization that is incompatible with Oracle Java's (Android, I am looking at you), we have to decouple SezPoz from the vagaries of `TreeMap`'s serialization.

To maintain backwards-compatibility, we still accept `.jar` files whose annotations were serialized by a previous SezPoz version.

This is intended to fix issue #6.
