### PR TITLE
[JENKINS-4409] Disable URLClassLoader cache before opening stream

### DIFF
--- a/sezpoz/src/main/java/net/java/sezpoz/Index.java
+++ b/sezpoz/src/main/java/net/java/sezpoz/Index.java
@@ -37,6 +37,7 @@ import java.io.ObjectInputStream;
 import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -148,7 +149,9 @@ public final class Index<A extends Annotation,I> implements Iterable<IndexItem<A
                         }
                         resource = resources.nextElement();
                         LOGGER.log(Level.FINE, "Loading index from {0}", resource);
-                        ois = new ObjectInputStream(resource.openStream());
+                        URLConnection uc = resource.openConnection();
+                        uc.setUseCaches(false);
+                        ois = new ObjectInputStream(uc.getInputStream());
                     }
                     SerAnnotatedElement el = (SerAnnotatedElement) ois.readObject();
                     if (el == null) {


### PR DESCRIPTION
This commit implements a workaround for https://bugs.openjdk.java.net/browse/JDK-8013099

The previous behaviour was causing retention of file handles, resulting
in temp folder leaks when executing Jenkins test cases.