### PR TITLE
Fix use of SezPoz with more modern JDKs by catching NoSuchFileException as well as FileNotFoundException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.5.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/sezpoz/pom.xml
+++ b/sezpoz/pom.xml
@@ -26,6 +26,7 @@
                 <configuration>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
+                <version>3.7.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer.java
+++ b/sezpoz/src/main/java/net/java/sezpoz/impl/Indexer.java
@@ -44,6 +44,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -194,7 +195,7 @@ public class Indexer extends AbstractProcessor {
                     } finally {
                         is.close();
                     }
-                } catch (FileNotFoundException x) {
+                } catch (FileNotFoundException|NoSuchFileException x) {
                     // OK, created for the first time
                 }
                 FileObject out = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT,
@@ -298,7 +299,6 @@ public class Indexer extends AbstractProcessor {
     /**
      * Checks metadata of a proposed registration.
      * @param registration a class, method, or field
-     * @param annotation an indexable annotation applied to {@code registration}
      * @param indexable {@link Indexable} annotation on that annotation
      * @return an error message, or null if it is valid
      */


### PR DESCRIPTION
Basically the difference is that somewhere internally a shift was made to use NIO APIs when using JDK10. 

With this patch + one to metainf-services, I can now fully compile Jenkins under JDK 10, where previously exceptions would be thrown due to annotations not being created in the META-INF/annotations build directory. 