### PR TITLE
Use reuseForks=false instead of forkMode=pertest

### DIFF
--- a/sezpoz/pom.xml
+++ b/sezpoz/pom.xml
@@ -55,7 +55,7 @@
                     <excludes>
                         <exclude>**/TestUtils.java</exclude>
                     </excludes>
-                    <forkMode>pertest</forkMode>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
To fix the following warnings:

```
[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ sezpoz ---
[WARNING] The parameter forkMode is deprecated since version 2.14. Use forkCount and reuseForks instead.
```

Not specifying forkCount=1, given it's the default.

Cf. http://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html#Migrating_the_Deprecated_forkMode_Parameter_to_forkCount_and_reuseForks

And https://stackoverflow.com/a/40096619/345845 that nicely clarifies that `pertest` actually is synonymous to `always`.

@jglick 